### PR TITLE
Enable a prefix mode for uploading

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,11 @@ inputs:
     default: us-east-2
   bucket:
     description: 'S3 bucket to write to.'
+  prefix:
+    description: |
+      A directory prefix, where files in the specified `directory` end up at `/{prefix}/{filename}`.
+      Used only by Determinate Secure Packages, which specifies the release as the prefix.
+      This enables paths like `https://install.determinate.systems/secure-packages/0.904649.292/closure.json`.
   directory:
     description: 'directory to upload artifacts from'
   allowed_branches:
@@ -107,6 +112,7 @@ runs:
         IDS_BINARY_PREFIX:  ${{ inputs.ids_binary_prefix }}
         AWS_BUCKET: ${{ inputs.bucket }}
         RELEASE_TYPE: ${{ steps.determination.outputs.push_style }}
+        FLAT_MODE: ${{ inputs.flat_mode }}
         ARTIFACTS_DIRECTORY: ${{ inputs.directory }}
         SHA: ${{ steps.determination.outputs.sha }}
         NAME: ${{ steps.determination.outputs.name }}

--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,7 @@ runs:
         IDS_BINARY_PREFIX:  ${{ inputs.ids_binary_prefix }}
         AWS_BUCKET: ${{ inputs.bucket }}
         RELEASE_TYPE: ${{ steps.determination.outputs.push_style }}
-        FLAT_MODE: ${{ inputs.flat_mode }}
+        PREFIX: ${{ inputs.prefix }}
         ARTIFACTS_DIRECTORY: ${{ inputs.directory }}
         SHA: ${{ steps.determination.outputs.sha }}
         NAME: ${{ steps.determination.outputs.name }}

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,8 @@ inputs:
   prefix:
     description: |
       A directory prefix, where files in the specified `directory` end up at `/{prefix}/{filename}`.
-      Used only by Determinate Secure Packages, which specifies the release as the prefix.
-      This enables paths like `https://install.determinate.systems/secure-packages/0.904649.292/closure.json`.
+      Used only by Determinate Secure Packages, which specifies the variant (`secure` or `secure-fips`) and the release (e.g. `0.904649.292`) as the prefix.
+      This enables paths like `https://install.determinate.systems/secure-packages/secure-fips/0.904649.292/closure.json`.
   directory:
     description: 'directory to upload artifacts from'
   allowed_branches:

--- a/upload_s3.sh
+++ b/upload_s3.sh
@@ -2,6 +2,39 @@
 set -eux
 
 ARTIFACTS_DIRECTORY="$1"
+
+# Prefix mode: upload artifacts with a `prefix` and don't use the tag/branch/etc logic
+if [[ -n "${PREFIX:-}" ]]; then 
+  base_s3_path="${IDS_PROJECT}/${PREFIX}"
+
+  sync_args=()
+  if [[ "${SKIP_ACL:-false}" != "true" ]]; then
+    sync_args+=(--acl public-read)
+  fi
+
+  find "$ARTIFACTS_DIRECTORY" -type f -print0 |
+    while IFS= read -r -d '' file; do
+      relative_path="${file#$ARTIFACTS_DIRECTORY/}"
+      s3_key="${base_s3_path}/${relative_path}"
+      
+      aws s3api put-object \
+        --bucket "$AWS_BUCKET" \
+        --key "$s3_key" \
+        --body "$file" \
+        "${sync_args[@]}"
+      
+      cat <<-EOF >> "$GITHUB_STEP_SUMMARY"
+\`\`\`
+curl --proto '=https' --tlsv1.2 -sSf -L 'https://install.determinate.systems/${s3_key}'
+\`\`\`
+
+EOF
+    done
+
+  exit 0
+fi
+
+# Tag/branch/etc logic
 TYPE="$2"
 TYPE_ID="$3"
 GIT_ISH="$4"


### PR DESCRIPTION
This PR enables supplying a `prefix` parameter instead of `ids_binary_prefix`. When you do that, `push-artifact-ids` bypasses the tag/revision/branch/etc logic and uploads everything in `directory` to `{ids_project_name}/{prefix}/{filename}`. An example:

```yaml
- uses: DeterminateSystems/push-artifact-ids@main
  with:
    s3_upload_role: ${{ secrets.AWS_S3_UPLOAD_ROLE }}
    bucket: ${{ secrets.AWS_S3_UPLOAD_BUCKET }}
    directory: ./artifacts
    ids_project_name: secure-packages
    prefix: '${{ env.SECURE_PACKAGES_VARIANT }}/${{ env.SECURE_PACKAGES_RELEASE }}'
```

This would take everything in `./artifacts` and make it available at `/secure-packages/{prefix}/{filename}`, so that `./artifacts/closure.json` for release `0.904649.292`, for example, would end up at:

https://install.determinate.systems/secure-packages/0.904649.292/closure.json

This is intended for use by Determinate Secure Packages but could be used for other things.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `prefix` input to customize S3 upload locations for artifacts.
  * When `prefix` is provided, artifacts are uploaded to S3 paths combining the project identifier with the prefix, enabling flexible storage organization.
  * In prefix mode, the upload step runs the prefix-based publish flow (and then completes), simplifying targeted artifact publishing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->